### PR TITLE
feat: change ripples command to use positional arguments for files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ cargo audit                   # Security audit
 ```bash
 cargo run -- inspect          # Check for circular dependencies
 cargo run -- spectacle        # Generate dependency graph visualization
-cargo run -- ripples --files src/lib.rs  # Find affected workspaces
+cargo run -- ripples src/lib.rs  # Find affected workspaces
 cargo run -- lineup           # List all dependencies
 cargo run -- spotlight <crate>  # Analyze specific crate
 ```

--- a/README.md
+++ b/README.md
@@ -188,26 +188,23 @@ Unlike naive approaches that rebuild everything or guess based on directory name
 
 ```bash
 # Show what's affected by changed files
-cargo ferris-wheel ripples --files src/lib.rs,tests/integration.rs
+cargo ferris-wheel ripples src/lib.rs tests/integration.rs
 
 # Include crate-level information in output
-cargo ferris-wheel ripples --files src/lib.rs --show-crates
+cargo ferris-wheel ripples src/lib.rs --show-crates
 
 # Show only directly affected crates (no reverse dependencies)
-cargo ferris-wheel ripples --files src/lib.rs --direct-only
+cargo ferris-wheel ripples src/lib.rs --direct-only
 
 # Output as JSON for CI integration
-cargo ferris-wheel ripples --files src/lib.rs --format json
+cargo ferris-wheel ripples src/lib.rs --format json
 
-# Multiple files can be specified
-cargo ferris-wheel ripples --files src/lib.rs --files src/main.rs
-
-# Or use comma separation
-cargo ferris-wheel ripples --files src/lib.rs,src/main.rs,Cargo.toml
+# Multiple files can be specified as positional arguments
+cargo ferris-wheel ripples src/lib.rs src/main.rs Cargo.toml
 
 # Exclude specific dependency types from analysis
-cargo ferris-wheel ripples --files src/lib.rs --exclude-dev
-cargo ferris-wheel ripples --files src/lib.rs --exclude-build --exclude-target
+cargo ferris-wheel ripples src/lib.rs --exclude-dev
+cargo ferris-wheel ripples src/lib.rs --exclude-build --exclude-target
 ```
 
 Example JSON output:
@@ -486,10 +483,10 @@ jobs:
 - name: Analyze affected workspaces
   run: |
     # Get list of changed files from git
-    CHANGED_FILES=$(git diff --name-only origin/main...HEAD | paste -sd "," -)
+    CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
 
     # Use ferris-wheel to determine affected workspaces
-    AFFECTED=$(cargo ferris-wheel ripples --files "$CHANGED_FILES" --format json)
+    AFFECTED=$(cargo ferris-wheel ripples $CHANGED_FILES --format json)
     echo "$AFFECTED"
 
     # Extract just the workspace names for your build matrix
@@ -499,7 +496,7 @@ jobs:
 # Example: Only run if specific workspaces are affected
 - name: Build affected workspaces
   run: |
-    AFFECTED=$(cargo ferris-wheel ripples --files "$CHANGED_FILES" --format json)
+    AFFECTED=$(cargo ferris-wheel ripples $CHANGED_FILES --format json)
     if echo "$AFFECTED" | jq -e '.affected_workspaces | contains(["core"])'; then
       echo "Core workspace affected, running specialized tests..."
       cargo test -p core

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -196,11 +196,11 @@ pub enum Commands {
                       Supports JSON output for easy integration."
     )]
     Ripples {
-        /// List of changed files (comma-separated or specify multiple times)
+        /// List of changed files
         #[arg(
-            long,
-            value_delimiter = ',',
             required = true,
+            value_name = "FILES",
+            help = "Files that have changed",
             env = "CARGO_FERRIS_WHEEL_FILES"
         )]
         files: Vec<String>,
@@ -213,8 +213,17 @@ pub enum Commands {
         #[arg(long, env = "CARGO_FERRIS_WHEEL_DIRECT_ONLY")]
         direct_only: bool,
 
-        #[command(flatten)]
-        common: CommonArgs,
+        /// Exclude dev-dependencies from analysis
+        #[arg(long, env = "CARGO_FERRIS_WHEEL_EXCLUDE_DEV")]
+        exclude_dev: bool,
+
+        /// Exclude build-dependencies from analysis
+        #[arg(long, env = "CARGO_FERRIS_WHEEL_EXCLUDE_BUILD")]
+        exclude_build: bool,
+
+        /// Exclude target-specific dependencies
+        #[arg(long, env = "CARGO_FERRIS_WHEEL_EXCLUDE_TARGET")]
+        exclude_target: bool,
 
         #[command(flatten)]
         format: FormatArgs,

--- a/src/commands/affected.rs
+++ b/src/commands/affected.rs
@@ -39,17 +39,21 @@ impl FromCommand for AffectedConfig {
                 files,
                 show_crates,
                 direct_only,
-                common,
+                exclude_dev,
+                exclude_build,
+                exclude_target,
                 format,
             } => AffectedConfig::builder()
                 .with_files(files)
                 .with_show_crates(show_crates)
                 .with_direct_only(direct_only)
-                .with_paths(common.get_paths())
+                .with_paths(vec![
+                    std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+                ])
                 .with_format(format.format)
-                .with_exclude_dev(common.exclude_dev)
-                .with_exclude_build(common.exclude_build)
-                .with_exclude_target(common.exclude_target)
+                .with_exclude_dev(exclude_dev)
+                .with_exclude_build(exclude_build)
+                .with_exclude_target(exclude_target)
                 .build(),
             _ => Err(FerrisWheelError::ConfigurationError {
                 message: "Invalid command type for AffectedConfig".to_string(),


### PR DESCRIPTION
Replace --files flag with positional arguments for better ergonomics. Users can now run: cargo ferris-wheel ripples file1 file2 file3

Changes:
- Remove --files flag, make files positional arguments
- Remove CommonArgs from ripples to avoid PATH conflict
- Add exclude flags directly to ripples command
- Update all documentation and examples

This provides a cleaner, more intuitive CLI experience.