### PR TITLE
feat: disambiguate duplicate crates across workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,11 @@ The `ripples` command is the star of our CI circus! This precision tool determin
 **What it does:**
 
 - Maps changed files to their containing crates
+- Canonicalizes crates by their manifest paths so duplicate package names stay unique across workspaces
 - Traces dependencies to find all affected components
 - Distinguishes between directly and indirectly affected crates
 - Provides both workspace and crate-level impact analysis
+- Resolves workspace dependencies via Cargo metadata rather than directory-name heuristics
 - Outputs machine-readable formats for CI integration
 
 **When to use it:**
@@ -182,7 +184,9 @@ The `ripples` command is the star of our CI circus! This precision tool determin
 Unlike naive approaches that rebuild everything or guess based on directory names, `ripples` understands your actual dependency graph. It precisely identifies affected components, even when:
 
 - Multiple crates exist in a single workspace
+- Different workspaces reuse the same crate name
 - Changes affect shared dependencies
+- Workspace directories diverge from their package names
 - File moves or renames occur
 - Only test files are modified
 

--- a/src/analyzer/analyzer_impl.rs
+++ b/src/analyzer/analyzer_impl.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 
 use console::style;
@@ -29,13 +29,17 @@ pub enum CrateMemberBuilderError {
 }
 
 // Type aliases to reduce complexity
-type WorkspaceProcessResult = (PathBuf, WorkspaceInfo, Vec<(String, PathBuf)>);
+pub type CrateWorkspaceMap = HashMap<String, BTreeSet<PathBuf>>;
+pub type CratePathToWorkspaceMap = HashMap<PathBuf, PathBuf>;
+
+type WorkspaceProcessResult = (PathBuf, WorkspaceInfo);
 type ParallelProcessResults = Vec<WorkspaceProcessResult>;
 
 #[derive(Debug, Clone)]
 pub struct WorkspaceAnalyzer {
     workspaces: HashMap<PathBuf, WorkspaceInfo>,
-    crate_to_workspace: HashMap<String, PathBuf>,
+    crate_to_workspaces: CrateWorkspaceMap,
+    crate_path_to_workspace: CratePathToWorkspaceMap,
     crate_to_paths: HashMap<String, Vec<PathBuf>>,
 }
 
@@ -226,6 +230,8 @@ impl CrateMemberBuilder {
 pub struct Dependency {
     name: String,
     target: Option<String>,
+    path: Option<PathBuf>,
+    is_workspace: bool,
 }
 
 impl Dependency {
@@ -240,12 +246,22 @@ impl Dependency {
     pub fn target(&self) -> Option<&str> {
         self.target.as_deref()
     }
+
+    pub fn path(&self) -> Option<&PathBuf> {
+        self.path.as_ref()
+    }
+
+    pub fn is_workspace(&self) -> bool {
+        self.is_workspace
+    }
 }
 
 #[derive(Default)]
 pub struct DependencyBuilder {
     name: Option<String>,
     target: Option<String>,
+    path: Option<PathBuf>,
+    is_workspace: bool,
 }
 
 #[derive(Error, Debug, Diagnostic)]
@@ -263,6 +279,8 @@ impl From<&Dependency> for DependencyBuilder {
         Self {
             name: Some(dep.name().to_string()),
             target: dep.target().map(|t| t.to_string()),
+            path: dep.path().cloned(),
+            is_workspace: dep.is_workspace(),
         }
     }
 }
@@ -278,10 +296,22 @@ impl DependencyBuilder {
         self
     }
 
+    pub fn with_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    pub fn with_is_workspace(mut self, is_workspace: bool) -> Self {
+        self.is_workspace = is_workspace;
+        self
+    }
+
     pub fn build(self) -> Result<Dependency, DependencyBuilderError> {
         Ok(Dependency {
             name: self.name.ok_or(DependencyBuilderError::MissingName)?,
             target: self.target,
+            path: self.path,
+            is_workspace: self.is_workspace,
         })
     }
 }
@@ -296,7 +326,8 @@ impl WorkspaceAnalyzer {
     pub fn new() -> Self {
         Self {
             workspaces: HashMap::new(),
-            crate_to_workspace: HashMap::new(),
+            crate_to_workspaces: HashMap::new(),
+            crate_path_to_workspace: HashMap::new(),
             crate_to_paths: HashMap::new(),
         }
     }
@@ -305,8 +336,12 @@ impl WorkspaceAnalyzer {
         &self.workspaces
     }
 
-    pub fn crate_to_workspace(&self) -> &HashMap<String, PathBuf> {
-        &self.crate_to_workspace
+    pub fn crate_to_workspace(&self) -> &CrateWorkspaceMap {
+        &self.crate_to_workspaces
+    }
+
+    pub fn crate_path_to_workspace(&self) -> &CratePathToWorkspaceMap {
+        &self.crate_path_to_workspace
     }
 
     pub fn crate_to_paths(&self) -> &HashMap<String, Vec<PathBuf>> {
@@ -395,19 +430,41 @@ impl WorkspaceAnalyzer {
     }
 
     fn merge_results(&mut self, results: ParallelProcessResults) {
-        for (path, info, crate_mappings) in results {
-            // Populate crate_to_paths mapping from the workspace info
-            for member in &info.members {
-                self.crate_to_paths
+        for (workspace_path, mut info) in results {
+            let workspace_key = workspace_path
+                .canonicalize()
+                .unwrap_or_else(|_| workspace_path.clone());
+
+            // Populate crate lookups from the workspace info
+            for member in &mut info.members {
+                let crate_path = member
+                    .path
+                    .canonicalize()
+                    .unwrap_or_else(|_| member.path.clone());
+
+                member.path = crate_path.clone();
+
+                if let Some(entry) = self.crate_to_paths.get_mut(&member.name) {
+                    if !entry.iter().any(|existing| existing == &crate_path) {
+                        entry.push(crate_path.clone());
+                    }
+                } else {
+                    self.crate_to_paths
+                        .entry(member.name.clone())
+                        .or_default()
+                        .push(crate_path.clone());
+                }
+
+                self.crate_to_workspaces
                     .entry(member.name.clone())
                     .or_default()
-                    .push(member.path.clone());
+                    .insert(workspace_key.clone());
+
+                self.crate_path_to_workspace
+                    .insert(crate_path, workspace_key.clone());
             }
 
-            self.workspaces.insert(path, info);
-            for (crate_name, workspace_path) in crate_mappings {
-                self.crate_to_workspace.insert(crate_name, workspace_path);
-            }
+            self.workspaces.insert(workspace_key, info);
         }
     }
 
@@ -445,7 +502,7 @@ impl WorkspaceAnalyzer {
         root: WorkspaceRoot,
     ) -> Result<WorkspaceProcessResult> {
         // Process members in parallel and collect both results and errors
-        let results: Vec<Result<(CrateMember, String)>> = root
+        let results: Vec<Result<CrateMember>> = root
             .members()
             .par_iter()
             .map(|member| {
@@ -456,18 +513,17 @@ impl WorkspaceAnalyzer {
                     root.workspace_dependencies(),
                     root.path(),
                 )
-                .map(|crate_member| (crate_member, member.name().to_string()))
                 .wrap_err_with(|| format!("Failed to analyze crate '{}'", member.name()))
             })
             .collect();
 
         // Separate successful results from errors
-        let mut members_with_mappings = Vec::new();
+        let mut members = Vec::new();
         let mut crate_errors = Vec::new();
 
         for result in results {
             match result {
-                Ok(data) => members_with_mappings.push(data),
+                Ok(member) => members.push(member),
                 Err(e) => crate_errors.push(e),
             }
         }
@@ -477,23 +533,13 @@ impl WorkspaceAnalyzer {
             eprintln!("{} {}", style("⚠").yellow(), error);
         }
 
-        let members: Vec<CrateMember> = members_with_mappings
-            .iter()
-            .map(|(m, _)| m.clone())
-            .collect();
-
-        let crate_mappings: Vec<(String, PathBuf)> = members_with_mappings
-            .into_iter()
-            .map(|(_, name)| (name, root.path().clone()))
-            .collect();
-
         let workspace_info = WorkspaceInfo {
             name: root.name().to_string(),
             members,
             is_standalone: root.is_standalone(),
         };
 
-        Ok((root.path().clone(), workspace_info, crate_mappings))
+        Ok((root.path().clone(), workspace_info))
     }
 
     fn analyze_crate_member(
@@ -520,7 +566,9 @@ impl WorkspaceAnalyzer {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
     use std::fs;
+    use std::path::PathBuf;
 
     use tempfile::TempDir;
 
@@ -600,5 +648,93 @@ crate-a = { path = "../crate-a" }
         // Check crate-b dependencies
         let crate_b = ws.members.iter().find(|m| m.name == "crate-b").unwrap();
         assert_eq!(crate_b.dev_dependencies.len(), 1); // crate-a
+    }
+
+    #[test]
+    fn test_duplicate_crate_names_map_to_multiple_workspaces() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+
+        let workspace_a = root.join("workspace-a");
+        let workspace_b = root.join("workspace-b");
+
+        fs::create_dir_all(workspace_a.join("shared/src")).unwrap();
+        fs::create_dir_all(workspace_b.join("shared/src")).unwrap();
+
+        fs::write(
+            workspace_a.join("Cargo.toml"),
+            r#"
+[workspace]
+members = ["shared"]
+"#,
+        )
+        .unwrap();
+        fs::write(
+            workspace_a.join("shared/Cargo.toml"),
+            "[package]\nname = \"shared\"\n",
+        )
+        .unwrap();
+        fs::write(workspace_a.join("shared/src/lib.rs"), "pub fn a() {}").unwrap();
+
+        fs::write(
+            workspace_b.join("Cargo.toml"),
+            r#"
+[workspace]
+members = ["shared"]
+"#,
+        )
+        .unwrap();
+        fs::write(
+            workspace_b.join("shared/Cargo.toml"),
+            "[package]\nname = \"shared\"\n",
+        )
+        .unwrap();
+        fs::write(workspace_b.join("shared/src/lib.rs"), "pub fn b() {}").unwrap();
+
+        let mut analyzer = WorkspaceAnalyzer::new();
+        analyzer
+            .discover_workspaces(&[root.to_path_buf()], None)
+            .unwrap();
+
+        let shared_entries = analyzer
+            .crate_to_workspace()
+            .get("shared")
+            .expect("shared crate should be indexed");
+
+        let expected_ws_paths: BTreeSet<PathBuf> = [
+            workspace_a.canonicalize().unwrap(),
+            workspace_b.canonicalize().unwrap(),
+        ]
+        .into_iter()
+        .collect();
+
+        let actual_ws_paths: BTreeSet<PathBuf> = shared_entries
+            .iter()
+            .map(|p| p.canonicalize().unwrap())
+            .collect();
+
+        assert_eq!(actual_ws_paths, expected_ws_paths);
+
+        let crate_paths = analyzer
+            .crate_to_paths()
+            .get("shared")
+            .expect("crate paths should be tracked");
+        assert_eq!(crate_paths.len(), 2);
+
+        for crate_path in crate_paths {
+            let resolved = crate_path.canonicalize().unwrap();
+            let ws = analyzer
+                .crate_path_to_workspace()
+                .get(crate_path)
+                .expect("crate path should map to workspace");
+            let ws_abs = ws.canonicalize().unwrap();
+            assert!(expected_ws_paths.contains(&ws_abs));
+            assert!(
+                resolved.starts_with(&ws_abs),
+                "crate {:?} should live under workspace {:?}",
+                resolved,
+                ws_abs
+            );
+        }
     }
 }

--- a/src/analyzer/analyzer_impl.rs
+++ b/src/analyzer/analyzer_impl.rs
@@ -731,9 +731,7 @@ members = ["shared"]
             assert!(expected_ws_paths.contains(&ws_abs));
             assert!(
                 resolved.starts_with(&ws_abs),
-                "crate {:?} should live under workspace {:?}",
-                resolved,
-                ws_abs
+                "crate {resolved:?} should live under workspace {ws_abs:?}"
             );
         }
     }

--- a/src/commands/affected.rs
+++ b/src/commands/affected.rs
@@ -8,7 +8,7 @@ use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::EdgeRef;
 use serde::{Deserialize, Serialize};
 
-use crate::analyzer::WorkspaceInfo;
+use crate::analyzer::{CratePathToWorkspaceMap, Dependency, WorkspaceInfo};
 use crate::cli::Commands;
 use crate::common::FromCommand;
 use crate::config::AffectedConfig;
@@ -36,6 +36,26 @@ pub struct AffectedCrate {
     pub workspace: String,
     pub is_directly_affected: bool,
     pub is_standalone: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub(crate) struct CrateId {
+    name: String,
+    path: PathBuf,
+}
+
+impl CrateId {
+    fn new(name: String, path: PathBuf) -> Self {
+        Self { name, path }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
 }
 
 impl FromCommand for AffectedConfig {
@@ -82,17 +102,16 @@ pub fn execute_affected_command(command: Commands) -> Result<()> {
 
 /// Analysis of affected crates and workspaces based on changed files
 pub struct AffectedAnalysis {
-    /// Map from (crate_name, crate_path) to workspace path
-    crate_path_to_workspace: HashMap<(String, PathBuf), PathBuf>,
-    /// Map from crate name to crate paths (can have multiple paths per crate
-    /// name)
-    crate_to_paths: HashMap<String, Vec<PathBuf>>,
+    /// Map from crate identifier to its workspace path
+    crate_workspace_index: HashMap<CrateId, PathBuf>,
+    /// Map from crate path to crate identifier for quick lookup
+    crate_path_index: HashMap<PathBuf, CrateId>,
     /// Map from workspace path to workspace info
     workspaces: HashMap<PathBuf, WorkspaceInfo>,
-    /// Crate-level dependency graph
-    crate_graph: DiGraph<String, ()>,
-    /// Map from crate name to node index in the graph
-    crate_node_indices: HashMap<String, NodeIndex>,
+    /// Crate-level dependency graph keyed by crate identifier
+    crate_graph: DiGraph<CrateId, ()>,
+    /// Map from crate identifier to node index in the graph
+    crate_node_indices: HashMap<CrateId, NodeIndex>,
 }
 
 impl AffectedAnalysis {
@@ -102,75 +121,95 @@ impl AffectedAnalysis {
 
     pub fn new(
         workspaces: &HashMap<PathBuf, WorkspaceInfo>,
-        _crate_to_workspace: &HashMap<String, PathBuf>,
-        crate_to_paths: &HashMap<String, Vec<PathBuf>>,
+        crate_path_to_workspace: &CratePathToWorkspaceMap,
         filter: DependencyFilter,
     ) -> Result<Self, FerrisWheelError> {
         let mut crate_graph = DiGraph::new();
         let mut crate_node_indices = HashMap::new();
-        let mut crate_path_to_workspace = HashMap::new();
+        let mut crate_workspace_index = HashMap::new();
+        let mut crate_path_index = HashMap::new();
+        let mut crate_ids_by_name: HashMap<String, Vec<CrateId>> = HashMap::new();
 
         // First pass: create nodes for all crates and build proper mappings
         for (workspace_path, workspace_info) in workspaces {
+            let workspace_path = workspace_path.clone();
             for member in workspace_info.members() {
-                // Add node to graph
-                let node_idx = crate_graph.add_node(member.name().to_string());
-                crate_node_indices.insert(member.name().to_string(), node_idx);
+                let crate_path = member
+                    .path()
+                    .canonicalize()
+                    .unwrap_or_else(|_| member.path().clone());
+                let crate_id = CrateId::new(member.name().to_string(), crate_path.clone());
+                let node_idx = crate_graph.add_node(crate_id.clone());
+                crate_node_indices.insert(crate_id.clone(), node_idx);
 
-                // Map (crate_name, crate_path) to workspace
-                crate_path_to_workspace.insert(
-                    (member.name().to_string(), member.path().clone()),
-                    workspace_path.clone(),
+                crate_workspace_index.insert(
+                    crate_id.clone(),
+                    crate_path_to_workspace
+                        .get(&crate_path)
+                        .cloned()
+                        .unwrap_or_else(|| workspace_path.clone()),
                 );
+
+                crate_path_index.insert(crate_path.clone(), crate_id.clone());
+
+                crate_ids_by_name
+                    .entry(crate_id.name().to_string())
+                    .or_default()
+                    .push(crate_id);
             }
         }
 
         // Second pass: add edges based on dependencies
-        for workspace_info in workspaces.values() {
+        for (workspace_path, workspace_info) in workspaces {
             for member in workspace_info.members() {
-                if let Some(&from_idx) = crate_node_indices.get(member.name()) {
-                    // Add edges for all dependency types
-                    for dep in member.dependencies() {
-                        if let Some(&to_idx) = crate_node_indices.get(dep.name()) {
-                            crate_graph.add_edge(from_idx, to_idx, ());
-                        }
-                    }
+                let crate_path = member
+                    .path()
+                    .canonicalize()
+                    .unwrap_or_else(|_| member.path().clone());
+                let Some(from_id) = crate_path_index.get(&crate_path).cloned() else {
+                    continue;
+                };
+                let &from_idx = crate_node_indices
+                    .get(&from_id)
+                    .expect("crate node must exist for analyzed member");
 
-                    // Include dev dependencies unless excluded
-                    if filter.include_dev() {
-                        for dep in member.dev_dependencies() {
-                            if let Some(&to_idx) = crate_node_indices.get(dep.name()) {
-                                crate_graph.add_edge(from_idx, to_idx, ());
-                            }
-                        }
-                    }
+                let mut ctx = DependencyGraphContext {
+                    crate_graph: &mut crate_graph,
+                    crate_node_indices: &crate_node_indices,
+                    crate_ids_by_name: &crate_ids_by_name,
+                    crate_path_index: &crate_path_index,
+                    workspace_path: workspace_path.as_path(),
+                };
 
-                    // Include build dependencies unless excluded
-                    if filter.include_build() {
-                        for dep in member.build_dependencies() {
-                            if let Some(&to_idx) = crate_node_indices.get(dep.name()) {
-                                crate_graph.add_edge(from_idx, to_idx, ());
-                            }
-                        }
-                    }
+                connect_dependencies(member.dependencies(), true, from_idx, &from_id, &mut ctx);
 
-                    // Include target-specific dependencies unless excluded
-                    if filter.include_target() {
-                        for target_deps in member.target_dependencies().values() {
-                            for dep in target_deps {
-                                if let Some(&to_idx) = crate_node_indices.get(dep.name()) {
-                                    crate_graph.add_edge(from_idx, to_idx, ());
-                                }
-                            }
-                        }
+                connect_dependencies(
+                    member.dev_dependencies(),
+                    filter.include_dev(),
+                    from_idx,
+                    &from_id,
+                    &mut ctx,
+                );
+
+                connect_dependencies(
+                    member.build_dependencies(),
+                    filter.include_build(),
+                    from_idx,
+                    &from_id,
+                    &mut ctx,
+                );
+
+                if filter.include_target() {
+                    for deps in member.target_dependencies().values() {
+                        connect_dependencies(deps, true, from_idx, &from_id, &mut ctx);
                     }
                 }
             }
         }
 
         Ok(Self {
-            crate_path_to_workspace,
-            crate_to_paths: crate_to_paths.clone(),
+            crate_workspace_index,
+            crate_path_index,
             workspaces: workspaces.clone(),
             crate_graph,
             crate_node_indices,
@@ -182,8 +221,7 @@ impl AffectedAnalysis {
         &self,
         abs_file: &Path,
         cwd: &Path,
-        directly_affected_crates: &mut HashSet<String>,
-        directly_affected_crate_paths: &mut HashSet<(String, PathBuf)>,
+        directly_affected_crates: &mut HashSet<CrateId>,
     ) -> bool {
         // Check if this file is at a workspace root
         for ws_path in self.workspaces.keys() {
@@ -200,11 +238,12 @@ impl AffectedAnalysis {
             {
                 // This is a workspace-level Cargo file
                 // Mark all crates in this workspace as directly affected
-                for ((crate_name, crate_path), crate_ws_path) in &self.crate_path_to_workspace {
-                    if crate_ws_path == ws_path {
-                        directly_affected_crates.insert(crate_name.clone());
-                        directly_affected_crate_paths
-                            .insert((crate_name.clone(), crate_path.clone()));
+                for (crate_id, crate_ws_path) in &self.crate_workspace_index {
+                    let crate_ws_abs = crate_ws_path
+                        .canonicalize()
+                        .unwrap_or_else(|_| crate_ws_path.clone());
+                    if crate_ws_abs == abs_ws_path {
+                        directly_affected_crates.insert(crate_id.clone());
                     }
                 }
                 return true;
@@ -215,8 +254,7 @@ impl AffectedAnalysis {
 
     /// Analyze which crates and workspaces are affected by the given files
     pub fn analyze_affected_files(&self, files: &[String]) -> AffectedResult {
-        let mut directly_affected_crates = HashSet::new();
-        let mut directly_affected_crate_paths = HashSet::new();
+        let mut directly_affected_crates: HashSet<CrateId> = HashSet::new();
         let mut unmatched_files = Vec::new();
 
         // Get current directory once for efficiency
@@ -232,7 +270,6 @@ impl AffectedAnalysis {
             } else {
                 cwd.join(&file_path)
             };
-            // Try to canonicalize to resolve symlinks (e.g., /private/var -> /var on macOS)
             let abs_file = abs_file.canonicalize().unwrap_or(abs_file);
 
             // Check if this is a Cargo.lock or Cargo.toml file
@@ -241,53 +278,13 @@ impl AffectedAnalysis {
 
             // Handle workspace-level Cargo files
             if is_cargo_file
-                && self.handle_workspace_cargo_file(
-                    &abs_file,
-                    &cwd,
-                    &mut directly_affected_crates,
-                    &mut directly_affected_crate_paths,
-                )
+                && self.handle_workspace_cargo_file(&abs_file, &cwd, &mut directly_affected_crates)
             {
                 continue;
             }
 
-            // Try to find by checking if file is under any crate directory
-            // When multiple crates match, prefer the one with the longest matching path
-            let mut best_match: Option<(String, PathBuf, usize)> = None;
-
-            for (crate_name, crate_paths) in &self.crate_to_paths {
-                for crate_path in crate_paths {
-                    // Normalize the crate path to absolute and resolve symlinks
-                    let abs_crate = if crate_path.is_absolute() {
-                        crate_path.clone()
-                    } else {
-                        cwd.join(crate_path)
-                    };
-                    // Try to canonicalize to resolve symlinks
-                    let abs_crate = abs_crate.canonicalize().unwrap_or(abs_crate);
-
-                    // Check if the file is under this crate's directory
-                    if abs_file.starts_with(&abs_crate) {
-                        let match_len = abs_crate.as_os_str().len();
-                        match &best_match {
-                            None => {
-                                best_match =
-                                    Some((crate_name.clone(), crate_path.clone(), match_len))
-                            }
-                            Some((_, _, best_len)) => {
-                                if match_len > *best_len {
-                                    best_match =
-                                        Some((crate_name.clone(), crate_path.clone(), match_len));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            if let Some((crate_name, crate_path, _)) = best_match {
-                directly_affected_crates.insert(crate_name.clone());
-                directly_affected_crate_paths.insert((crate_name, crate_path));
+            if let Some(crate_id) = self.find_crate_for_file(&abs_file) {
+                directly_affected_crates.insert(crate_id);
             } else {
                 unmatched_files.push(file.clone());
             }
@@ -295,45 +292,20 @@ impl AffectedAnalysis {
 
         // Find all crates affected by reverse dependencies
         let mut all_affected_crates = directly_affected_crates.clone();
-        for crate_name in &directly_affected_crates {
-            if let Some(&node_idx) = self.crate_node_indices.get(crate_name) {
+        for crate_id in directly_affected_crates.iter() {
+            if let Some(&node_idx) = self.crate_node_indices.get(crate_id) {
                 self.find_reverse_dependencies(node_idx, &mut all_affected_crates);
             }
         }
 
-        // Map directly affected crates to workspaces using the exact paths that were
-        // matched
-        let directly_affected_workspaces: HashSet<String> = directly_affected_crate_paths
+        let directly_affected_workspaces: HashSet<String> = directly_affected_crates
             .iter()
-            .filter_map(|(crate_name, crate_path)| {
-                self.crate_path_to_workspace
-                    .get(&(crate_name.clone(), crate_path.clone()))
-                    .and_then(|ws_path| self.workspaces.get(ws_path))
-                    .map(|ws_info| ws_info.name().to_string())
-            })
+            .filter_map(|crate_id| self.workspace_name(crate_id))
             .collect();
 
-        // For all affected crates (including reverse dependencies), we need to find
-        // their workspaces
         let all_affected_workspaces: HashSet<String> = all_affected_crates
             .iter()
-            .flat_map(|crate_name| {
-                // A crate might exist in multiple workspaces, so collect all of them
-                self.crate_to_paths
-                    .get(crate_name)
-                    .map(|paths| {
-                        paths
-                            .iter()
-                            .filter_map(|path| {
-                                self.crate_path_to_workspace
-                                    .get(&(crate_name.clone(), path.clone()))
-                                    .and_then(|ws_path| self.workspaces.get(ws_path))
-                                    .map(|ws_info| ws_info.name().to_string())
-                            })
-                            .collect::<Vec<_>>()
-                    })
-                    .unwrap_or_default()
-            })
+            .filter_map(|crate_id| self.workspace_name(crate_id))
             .collect();
 
         AffectedResult {
@@ -345,7 +317,7 @@ impl AffectedAnalysis {
         }
     }
 
-    fn find_reverse_dependencies(&self, node_idx: NodeIndex, affected: &mut HashSet<String>) {
+    fn find_reverse_dependencies(&self, node_idx: NodeIndex, affected: &mut HashSet<CrateId>) {
         use petgraph::Direction;
 
         for edge in self
@@ -353,54 +325,169 @@ impl AffectedAnalysis {
             .edges_directed(node_idx, Direction::Incoming)
         {
             let source_idx = edge.source();
-            let source_crate = &self.crate_graph[source_idx];
+            let source_crate = self.crate_graph[source_idx].clone();
             if affected.insert(source_crate.clone()) {
                 // Recursively find more reverse dependencies
                 self.find_reverse_dependencies(source_idx, affected);
             }
         }
     }
+
+    fn find_crate_for_file(&self, abs_file: &Path) -> Option<CrateId> {
+        let canonical = abs_file
+            .canonicalize()
+            .unwrap_or_else(|_| abs_file.to_path_buf());
+
+        let mut best_match: Option<(usize, CrateId)> = None;
+
+        for (crate_path, crate_id) in &self.crate_path_index {
+            let match_path = (canonical.starts_with(crate_path)
+                || abs_file.starts_with(crate_path))
+            .then_some(crate_path);
+
+            if let Some(path) = match_path {
+                let match_len = path.as_os_str().len();
+                match &best_match {
+                    None => best_match = Some((match_len, crate_id.clone())),
+                    Some((best_len, _)) if match_len > *best_len => {
+                        best_match = Some((match_len, crate_id.clone()))
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        best_match.map(|(_, id)| id)
+    }
+
+    pub(crate) fn workspace_name(&self, crate_id: &CrateId) -> Option<String> {
+        self.crate_workspace_index
+            .get(crate_id)
+            .and_then(|ws_path| self.workspaces.get(ws_path))
+            .map(|ws| ws.name().to_string())
+    }
+}
+
+struct DependencyGraphContext<'a> {
+    crate_graph: &'a mut DiGraph<CrateId, ()>,
+    crate_node_indices: &'a HashMap<CrateId, NodeIndex>,
+    crate_ids_by_name: &'a HashMap<String, Vec<CrateId>>,
+    crate_path_index: &'a HashMap<PathBuf, CrateId>,
+    workspace_path: &'a Path,
+}
+
+fn connect_dependencies(
+    deps: &[Dependency],
+    include: bool,
+    from_idx: NodeIndex,
+    from_id: &CrateId,
+    ctx: &mut DependencyGraphContext<'_>,
+) {
+    if !include {
+        return;
+    }
+
+    for dep in deps {
+        if let Some(to_idx) = resolve_dependency_crate_id(
+            dep,
+            from_id,
+            ctx.workspace_path,
+            ctx.crate_ids_by_name,
+            ctx.crate_path_index,
+        )
+        .and_then(|target_id| ctx.crate_node_indices.get(&target_id).copied())
+        {
+            ctx.crate_graph.add_edge(from_idx, to_idx, ());
+        }
+    }
+}
+
+fn resolve_dependency_crate_id(
+    dep: &Dependency,
+    from_id: &CrateId,
+    workspace_path: &Path,
+    crate_ids_by_name: &HashMap<String, Vec<CrateId>>,
+    crate_path_index: &HashMap<PathBuf, CrateId>,
+) -> Option<CrateId> {
+    if let Some(dep_path) = dep.path() {
+        let base = if dep.is_workspace() {
+            workspace_path
+        } else {
+            from_id.path()
+        };
+
+        let absolute = if dep_path.is_absolute() {
+            dep_path.clone()
+        } else {
+            base.join(dep_path)
+        };
+
+        let canonical = absolute.canonicalize().unwrap_or_else(|_| absolute.clone());
+
+        crate_path_index
+            .get(&canonical)
+            .or_else(|| crate_path_index.get(&absolute))
+            .cloned()
+            .or_else(|| {
+                crate_path_index
+                    .iter()
+                    .find_map(|(candidate_path, candidate_id)| {
+                        if canonical.starts_with(candidate_path)
+                            || candidate_path.starts_with(&canonical)
+                        {
+                            Some(candidate_id.clone())
+                        } else {
+                            None
+                        }
+                    })
+            })
+    } else {
+        crate_ids_by_name.get(dep.name()).and_then(|ids| {
+            if ids.len() == 1 {
+                Some(ids[0].clone())
+            } else {
+                None
+            }
+        })
+    }
 }
 
 pub struct AffectedResult {
-    pub directly_affected_crates: HashSet<String>,
-    pub all_affected_crates: HashSet<String>,
-    pub directly_affected_workspaces: HashSet<String>,
-    pub all_affected_workspaces: HashSet<String>,
-    pub unmatched_files: Vec<String>,
+    pub(crate) directly_affected_crates: HashSet<CrateId>,
+    pub(crate) all_affected_crates: HashSet<CrateId>,
+    pub(crate) directly_affected_workspaces: HashSet<String>,
+    pub(crate) all_affected_workspaces: HashSet<String>,
+    pub(crate) unmatched_files: Vec<String>,
 }
 
 impl AffectedResult {
     pub fn to_json_report(&self, analysis: &AffectedAnalysis) -> AffectedJsonReport {
         let mut affected_crates = Vec::new();
 
-        for crate_name in &self.all_affected_crates {
-            // Get workspace info for this crate (prefer first path found)
+        for crate_id in &self.all_affected_crates {
             let workspace_info = analysis
-                .crate_to_paths
-                .get(crate_name)
-                .and_then(|paths| paths.first())
-                .and_then(|path| {
-                    analysis
-                        .crate_path_to_workspace
-                        .get(&(crate_name.clone(), path.clone()))
-                        .and_then(|ws_path| analysis.workspaces.get(ws_path))
-                });
+                .crate_workspace_index
+                .get(crate_id)
+                .and_then(|ws_path| analysis.workspaces.get(ws_path));
 
             let (workspace_name, is_standalone) = workspace_info
                 .map(|ws| (ws.name().to_string(), ws.is_standalone()))
                 .unwrap_or_else(|| ("unknown".to_string(), false));
 
             affected_crates.push(AffectedCrate {
-                name: crate_name.clone(),
+                name: crate_id.name().to_string(),
                 workspace: workspace_name,
-                is_directly_affected: self.directly_affected_crates.contains(crate_name),
+                is_directly_affected: self.directly_affected_crates.contains(crate_id),
                 is_standalone,
             });
         }
 
         // Sort affected crates by name for deterministic output
-        affected_crates.sort_by(|a, b| a.name.cmp(&b.name));
+        affected_crates.sort_by(|a, b| {
+            a.name
+                .cmp(&b.name)
+                .then_with(|| a.workspace.cmp(&b.workspace))
+        });
 
         // Create affected workspace objects with paths
         let mut affected_workspaces: Vec<AffectedWorkspace> = self
@@ -423,9 +510,13 @@ impl AffectedResult {
             .collect();
         affected_workspaces.sort_by(|a, b| a.name.cmp(&b.name));
 
-        let mut directly_affected_crates: Vec<String> =
-            self.directly_affected_crates.iter().cloned().collect();
+        let mut directly_affected_crates: Vec<String> = self
+            .directly_affected_crates
+            .iter()
+            .map(|crate_id| crate_id.name().to_string())
+            .collect();
         directly_affected_crates.sort();
+        directly_affected_crates.dedup();
 
         let mut directly_affected_workspaces: Vec<AffectedWorkspace> = self
             .directly_affected_workspaces
@@ -464,6 +555,14 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    fn contains_crate(crates: &HashSet<CrateId>, name: &str) -> bool {
+        crates.iter().any(|id| id.name() == name)
+    }
+
+    fn count_crate(crates: &HashSet<CrateId>, name: &str) -> usize {
+        crates.iter().filter(|id| id.name() == name).count()
+    }
 
     fn create_test_workspace_with_duplicates() -> TempDir {
         let temp = TempDir::new().unwrap();
@@ -653,8 +752,7 @@ version = "0.1.0"
 
         AffectedAnalysis::new(
             analyzer.workspaces(),
-            analyzer.crate_to_workspace(),
-            analyzer.crate_to_paths(),
+            analyzer.crate_path_to_workspace(),
             crate::dependency_filter::DependencyFilter::default(),
         )
         .unwrap()
@@ -672,7 +770,14 @@ version = "0.1.0"
         )];
         let result_a = analysis.analyze_affected_files(&files_a);
 
-        assert!(result_a.directly_affected_crates.contains("phoenix-v2-api"));
+        assert!(contains_crate(
+            &result_a.directly_affected_crates,
+            "phoenix-v2-api"
+        ));
+        assert_eq!(
+            count_crate(&result_a.directly_affected_crates, "phoenix-v2-api"),
+            1
+        );
         assert!(
             result_a
                 .directly_affected_workspaces
@@ -691,7 +796,14 @@ version = "0.1.0"
         )];
         let result_b = analysis.analyze_affected_files(&files_b);
 
-        assert!(result_b.directly_affected_crates.contains("phoenix-v2-api"));
+        assert!(contains_crate(
+            &result_b.directly_affected_crates,
+            "phoenix-v2-api"
+        ));
+        assert_eq!(
+            count_crate(&result_b.directly_affected_crates, "phoenix-v2-api"),
+            1
+        );
         assert!(
             result_b
                 .directly_affected_workspaces
@@ -702,6 +814,32 @@ version = "0.1.0"
                 .directly_affected_workspaces
                 .contains("workspace-a")
         );
+    }
+
+    #[test]
+    fn test_duplicate_crate_names_multiple_changes() {
+        let temp = create_test_workspace_with_duplicates();
+        let analysis = build_test_analysis(temp.path());
+
+        let files = vec![
+            format!(
+                "{}/workspace-a/phoenix-v2-api/src/lib.rs",
+                temp.path().display()
+            ),
+            format!(
+                "{}/workspace-b/phoenix-v2-api/src/main.rs",
+                temp.path().display()
+            ),
+        ];
+
+        let result = analysis.analyze_affected_files(&files);
+
+        assert_eq!(
+            count_crate(&result.directly_affected_crates, "phoenix-v2-api"),
+            2
+        );
+        assert!(result.directly_affected_workspaces.contains("workspace-a"));
+        assert!(result.directly_affected_workspaces.contains("workspace-b"));
     }
 
     #[test]
@@ -717,12 +855,12 @@ version = "0.1.0"
         let result = analysis.analyze_affected_files(&files);
 
         // crate-b should be directly affected
-        assert!(result.directly_affected_crates.contains("crate-b"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-b"));
         assert_eq!(result.directly_affected_crates.len(), 1);
 
         // crate-a should be affected via reverse dependency
-        assert!(result.all_affected_crates.contains("crate-a"));
-        assert!(result.all_affected_crates.contains("crate-b"));
+        assert!(contains_crate(&result.all_affected_crates, "crate-a"));
+        assert!(contains_crate(&result.all_affected_crates, "crate-b"));
         assert_eq!(result.all_affected_crates.len(), 2);
     }
 
@@ -756,7 +894,7 @@ version = "0.1.0"
         let files = vec!["my-workspace/crate-a/src/lib.rs".to_string()];
         let result = analysis.analyze_affected_files(&files);
 
-        assert!(result.directly_affected_crates.contains("crate-a"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-a"));
 
         // Restore original directory
         std::env::set_current_dir(original_dir).unwrap();
@@ -811,7 +949,7 @@ version = "0.1.0"
 
         // Should only count crate-a once
         assert_eq!(result.directly_affected_crates.len(), 1);
-        assert!(result.directly_affected_crates.contains("crate-a"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-a"));
     }
 
     #[test]
@@ -827,7 +965,10 @@ version = "0.1.0"
         let result = analysis.analyze_affected_files(&files);
 
         // Only consumer-crate should be directly affected
-        assert!(result.directly_affected_crates.contains("consumer-crate"));
+        assert!(contains_crate(
+            &result.directly_affected_crates,
+            "consumer-crate"
+        ));
 
         // Workspace B should be affected
         assert!(result.directly_affected_workspaces.contains("workspace-b"));
@@ -1150,8 +1291,8 @@ version = "0.1.0"
 
         // Both crates should be directly affected by their Cargo.toml files
         assert_eq!(result.directly_affected_crates.len(), 2);
-        assert!(result.directly_affected_crates.contains("crate-a"));
-        assert!(result.directly_affected_crates.contains("crate-b"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-a"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-b"));
 
         // The workspace should be affected
         assert!(result.directly_affected_workspaces.contains("my-workspace"));
@@ -1168,8 +1309,8 @@ version = "0.1.0"
 
         // Workspace Cargo.toml should affect all workspace members
         assert_eq!(result.directly_affected_crates.len(), 2);
-        assert!(result.directly_affected_crates.contains("crate-a"));
-        assert!(result.directly_affected_crates.contains("crate-b"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-a"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-b"));
         assert!(result.directly_affected_workspaces.contains("my-workspace"));
         assert!(result.unmatched_files.is_empty());
     }
@@ -1187,15 +1328,14 @@ version = "0.1.0"
         let result = analysis.analyze_affected_files(&files);
 
         // Standalone crate's Cargo.lock should map to the crate
-        assert!(
-            result
-                .directly_affected_crates
-                .contains("standalone-test-crate")
-        );
+        assert!(contains_crate(
+            &result.directly_affected_crates,
+            "standalone-test-crate",
+        ));
 
         // Workspace Cargo.lock should affect all workspace members
-        assert!(result.directly_affected_crates.contains("crate-a"));
-        assert!(result.directly_affected_crates.contains("crate-b"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-a"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-b"));
 
         // No unmatched files
         assert!(result.unmatched_files.is_empty());
@@ -1211,8 +1351,8 @@ version = "0.1.0"
         let result = analysis.analyze_affected_files(&files);
 
         // All workspace members should be directly affected
-        assert!(result.directly_affected_crates.contains("crate-a"));
-        assert!(result.directly_affected_crates.contains("crate-b"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-a"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-b"));
         assert_eq!(result.directly_affected_crates.len(), 2);
 
         // The workspace should be affected
@@ -1232,8 +1372,8 @@ version = "0.1.0"
         let result = analysis.analyze_affected_files(&files);
 
         // All workspace members should be directly affected
-        assert!(result.directly_affected_crates.contains("crate-a"));
-        assert!(result.directly_affected_crates.contains("crate-b"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-a"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-b"));
         assert_eq!(result.directly_affected_crates.len(), 2);
 
         // The workspace should be affected
@@ -1256,16 +1396,15 @@ version = "0.1.0"
         let result = analysis.analyze_affected_files(&files);
 
         // Only the standalone crate should be affected
-        assert!(
-            result
-                .directly_affected_crates
-                .contains("standalone-test-crate")
-        );
+        assert!(contains_crate(
+            &result.directly_affected_crates,
+            "standalone-test-crate",
+        ));
         assert_eq!(result.directly_affected_crates.len(), 1);
 
         // No workspace members should be affected
-        assert!(!result.directly_affected_crates.contains("crate-a"));
-        assert!(!result.directly_affected_crates.contains("crate-b"));
+        assert!(!contains_crate(&result.directly_affected_crates, "crate-a"));
+        assert!(!contains_crate(&result.directly_affected_crates, "crate-b"));
 
         // No unmatched files
         assert!(result.unmatched_files.is_empty());
@@ -1284,13 +1423,13 @@ version = "0.1.0"
         let result = analysis.analyze_affected_files(&files);
 
         // crate-b should be directly affected
-        assert!(result.directly_affected_crates.contains("crate-b"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-b"));
         assert_eq!(result.directly_affected_crates.len(), 1);
 
         // crate-a depends on crate-b, so it should be affected through reverse
         // dependencies
-        assert!(result.all_affected_crates.contains("crate-a"));
-        assert!(result.all_affected_crates.contains("crate-b"));
+        assert!(contains_crate(&result.all_affected_crates, "crate-a"));
+        assert!(contains_crate(&result.all_affected_crates, "crate-b"));
         assert_eq!(result.all_affected_crates.len(), 2);
     }
 
@@ -1308,8 +1447,8 @@ version = "0.1.0"
         let result = analysis.analyze_affected_files(&files);
 
         // All crates should be directly affected
-        assert!(result.directly_affected_crates.contains("crate-a"));
-        assert!(result.directly_affected_crates.contains("crate-b"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-a"));
+        assert!(contains_crate(&result.directly_affected_crates, "crate-b"));
         assert_eq!(result.directly_affected_crates.len(), 2);
 
         // No unmatched files
@@ -1410,9 +1549,18 @@ name = "outer-crate"
         )];
         let result = analysis.analyze_affected_files(&files);
 
-        assert!(result.directly_affected_crates.contains("inner-crate-a"));
-        assert!(result.directly_affected_crates.contains("inner-crate-b"));
-        assert!(!result.directly_affected_crates.contains("outer-crate"));
+        assert!(contains_crate(
+            &result.directly_affected_crates,
+            "inner-crate-a"
+        ));
+        assert!(contains_crate(
+            &result.directly_affected_crates,
+            "inner-crate-b"
+        ));
+        assert!(!contains_crate(
+            &result.directly_affected_crates,
+            "outer-crate"
+        ));
         assert_eq!(result.directly_affected_crates.len(), 2);
     }
 }

--- a/src/commands/affected.rs
+++ b/src/commands/affected.rs
@@ -134,10 +134,7 @@ impl AffectedAnalysis {
         for (workspace_path, workspace_info) in workspaces {
             let workspace_path = workspace_path.clone();
             for member in workspace_info.members() {
-                let crate_path = member
-                    .path()
-                    .canonicalize()
-                    .unwrap_or_else(|_| member.path().clone());
+                let crate_path = member.path().to_path_buf();
                 let crate_id = CrateId::new(member.name().to_string(), crate_path.clone());
                 let node_idx = crate_graph.add_node(crate_id.clone());
                 crate_node_indices.insert(crate_id.clone(), node_idx);
@@ -162,10 +159,7 @@ impl AffectedAnalysis {
         // Second pass: add edges based on dependencies
         for (workspace_path, workspace_info) in workspaces {
             for member in workspace_info.members() {
-                let crate_path = member
-                    .path()
-                    .canonicalize()
-                    .unwrap_or_else(|_| member.path().clone());
+                let crate_path = member.path().to_path_buf();
                 let Some(from_id) = crate_path_index.get(&crate_path).cloned() else {
                     continue;
                 };
@@ -346,7 +340,7 @@ impl AffectedAnalysis {
             .then_some(crate_path);
 
             if let Some(path) = match_path {
-                let match_len = path.as_os_str().len();
+                let match_len = path.components().count();
                 match &best_match {
                     None => best_match = Some((match_len, crate_id.clone())),
                     Some((best_len, _)) if match_len > *best_len => {

--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -9,7 +9,7 @@ use petgraph::graph::{DiGraph, NodeIndex};
 use petgraph::visit::{EdgeRef, IntoNodeReferences};
 use serde::{Deserialize, Serialize};
 
-use crate::analyzer::WorkspaceInfo;
+use crate::analyzer::{CrateWorkspaceMap, WorkspaceInfo};
 use crate::cli::Commands;
 use crate::common::{ConfigBuilder, FromCommand};
 use crate::config::WorkspaceDepsConfig;
@@ -85,7 +85,7 @@ pub struct WorkspaceDependencyAnalysis {
 impl WorkspaceDependencyAnalysis {
     pub fn new(
         workspaces: &HashMap<PathBuf, WorkspaceInfo>,
-        _crate_to_workspace: &HashMap<String, PathBuf>,
+        _crate_to_workspace: &CrateWorkspaceMap,
         graph: &DiGraph<WorkspaceNode, DependencyEdge>,
     ) -> Self {
         // Build node index lookup
@@ -458,17 +458,17 @@ mod tests {
     use petgraph::graph::DiGraph;
 
     use super::*;
-    use crate::analyzer::WorkspaceInfo;
+    use crate::analyzer::{CrateWorkspaceMap, WorkspaceInfo};
     use crate::graph::{DependencyEdge, WorkspaceNode};
 
     fn create_test_graph() -> (
         DiGraph<WorkspaceNode, DependencyEdge>,
         HashMap<PathBuf, WorkspaceInfo>,
-        HashMap<String, PathBuf>,
+        CrateWorkspaceMap,
     ) {
         let mut graph = DiGraph::new();
         let mut workspaces = HashMap::new();
-        let crate_to_workspace = HashMap::new();
+        let crate_to_workspace = CrateWorkspaceMap::new();
 
         // Create workspace nodes
         let node_a = graph.add_node(

--- a/src/common.rs
+++ b/src/common.rs
@@ -96,7 +96,7 @@ mod tests {
         let paths = args.get_paths();
         assert_eq!(paths.len(), 1);
         // Should default to current directory
-        assert!(paths[0].is_absolute() || paths[0] == PathBuf::from("."));
+        assert!(paths[0].is_absolute() || paths[0] == std::path::Path::new("."));
     }
 
     #[test]

--- a/src/executors/affected.rs
+++ b/src/executors/affected.rs
@@ -159,7 +159,7 @@ fn generate_human_report(
             .collect();
         sorted_crates.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
         for (workspace, crate_name) in sorted_crates {
-            writeln!(output, "    - {} ({})", crate_name, workspace)?
+            writeln!(output, "    - {crate_name} ({workspace})")?
         }
     }
     writeln!(
@@ -204,7 +204,7 @@ fn generate_human_report(
                 .collect();
             sorted_all_crates.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
             for (workspace, crate_name) in sorted_all_crates {
-                writeln!(output, "    - {} ({})", crate_name, workspace)?;
+                writeln!(output, "    - {crate_name} ({workspace})")?;
             }
         }
         writeln!(

--- a/src/executors/analyze.rs
+++ b/src/executors/analyze.rs
@@ -62,6 +62,8 @@ impl CommandExecutor for AnalyzeExecutor {
                 .build_cross_workspace_graph(
                     analyzer.workspaces(),
                     analyzer.crate_to_workspace(),
+                    analyzer.crate_path_to_workspace(),
+                    analyzer.crate_to_paths(),
                     progress.as_ref(),
                 )
                 .wrap_err("Failed to build cross-workspace dependency graph")?;

--- a/src/executors/check.rs
+++ b/src/executors/check.rs
@@ -96,6 +96,8 @@ impl CommandExecutor for CheckExecutor {
                 .build_cross_workspace_graph(
                     analyzer.workspaces(),
                     analyzer.crate_to_workspace(),
+                    analyzer.crate_path_to_workspace(),
+                    analyzer.crate_to_paths(),
                     progress.as_ref(),
                 )
                 .wrap_err("Failed to build cross-workspace dependency graph")?;

--- a/src/executors/deps.rs
+++ b/src/executors/deps.rs
@@ -50,6 +50,8 @@ impl CommandExecutor for DepsExecutor {
             .build_cross_workspace_graph(
                 analyzer.workspaces(),
                 analyzer.crate_to_workspace(),
+                analyzer.crate_path_to_workspace(),
+                analyzer.crate_to_paths(),
                 progress.as_ref(),
             )
             .wrap_err("Failed to build cross-workspace dependency graph")?;

--- a/src/executors/graph.rs
+++ b/src/executors/graph.rs
@@ -43,7 +43,13 @@ impl CommandExecutor for GraphExecutor {
             config.exclude_target,
         );
         graph_builder
-            .build_cross_workspace_graph(analyzer.workspaces(), analyzer.crate_to_workspace(), None)
+            .build_cross_workspace_graph(
+                analyzer.workspaces(),
+                analyzer.crate_to_workspace(),
+                analyzer.crate_path_to_workspace(),
+                analyzer.crate_to_paths(),
+                None,
+            )
             .wrap_err("Failed to build dependency graph")?;
 
         // Detect cycles if highlighting is requested

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -230,14 +230,6 @@ impl DependencyGraphBuilder {
                     }
                 }
             }
-
-            if targets.is_empty() {
-                for (crate_path, ws_path) in ctx.crate_path_to_workspace.iter() {
-                    if canonical.starts_with(crate_path) || crate_path.starts_with(&canonical) {
-                        targets.insert(ws_path.clone());
-                    }
-                }
-            }
         }
 
         if targets.is_empty()

--- a/src/graph/renderer.rs
+++ b/src/graph/renderer.rs
@@ -59,13 +59,11 @@ impl GraphRenderer {
         output: &mut dyn Write,
     ) -> Result<()> {
         if graph.node_count() == 0 {
-            writeln_out!(output, "No workspaces found to visualize")
-                .map_err(FerrisWheelError::from)?;
+            writeln_out!(output, "No workspaces found to visualize")?;
             return Ok(());
         }
 
-        writeln_out!(output, "\n📊 Workspace Dependency Graph\n")
-            .map_err(FerrisWheelError::from)?;
+        writeln_out!(output, "\n📊 Workspace Dependency Graph\n")?;
 
         // Build sets of workspace names involved in cycles for easy lookup
         let cycles_ws_names: Vec<Vec<String>> = cycles
@@ -88,20 +86,16 @@ impl GraphRenderer {
 
             // Print workspace header with cycle indicator
             if in_cycle && self.highlight_cycles {
-                writeln_out!(output, "┌─────────────────────────────────────┐")
-                    .map_err(FerrisWheelError::from)?;
-                writeln_out!(output, "│ {} ⚠️  IN CYCLE", ws_name)
-                    .map_err(FerrisWheelError::from)?;
-                writeln_out!(output, "└─────────────────────────────────────┘")
-                    .map_err(FerrisWheelError::from)?;
+                writeln_out!(output, "┌─────────────────────────────────────┐")?;
+                writeln_out!(output, "│ {} ⚠️  IN CYCLE", ws_name)?;
+                writeln_out!(output, "└─────────────────────────────────────┘")?;
             } else {
-                writeln_out!(output, "{}", ws_name).map_err(FerrisWheelError::from)?;
+                writeln_out!(output, "{}", ws_name)?;
             }
 
             // Show crates in this workspace if requested
             if self.show_crates && !node.crates().is_empty() {
-                writeln_out!(output, "  📦 Crates: {}", node.crates().join(", "))
-                    .map_err(FerrisWheelError::from)?;
+                writeln_out!(output, "  📦 Crates: {}", node.crates().join(", "))?;
             }
 
             // Aggregate edges by target and dependency type
@@ -115,8 +109,7 @@ impl GraphRenderer {
             }
 
             if edge_groups.is_empty() {
-                writeln_out!(output, "  └── (no cross-workspace dependencies)")
-                    .map_err(FerrisWheelError::from)?;
+                writeln_out!(output, "  └── (no cross-workspace dependencies)")?;
             } else {
                 // Sort groups by target workspace name and dependency type
                 let mut groups: Vec<_> = edge_groups.into_iter().collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@
 //! graph_builder.build_cross_workspace_graph(
 //!     analyzer.workspaces(),
 //!     analyzer.crate_to_workspace(),
+//!     analyzer.crate_path_to_workspace(),
+//!     analyzer.crate_to_paths(),
 //!     None, // no progress reporter
 //! )?;
 //!
@@ -93,6 +95,8 @@
 //! # graph_builder.build_cross_workspace_graph(
 //! #     analyzer.workspaces(),
 //! #     analyzer.crate_to_workspace(),
+//! #     analyzer.crate_path_to_workspace(),
+//! #     analyzer.crate_to_paths(),
 //! #     None,
 //! # )?;
 //! # let mut detector = CycleDetector::new();
@@ -144,6 +148,8 @@
 //! graph_builder.build_cross_workspace_graph(
 //!     analyzer.workspaces(),
 //!     analyzer.crate_to_workspace(),
+//!     analyzer.crate_path_to_workspace(),
+//!     analyzer.crate_to_paths(),
 //!     None,
 //! )?;
 //!
@@ -171,6 +177,8 @@
 //! # graph_builder.build_cross_workspace_graph(
 //! #     analyzer.workspaces(),
 //! #     analyzer.crate_to_workspace(),
+//! #     analyzer.crate_path_to_workspace(),
+//! #     analyzer.crate_to_paths(),
 //! #     None,
 //! # )?;
 //! # let mut detector = CycleDetector::new();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -177,7 +177,13 @@ fn test_readme_example_generation() {
     // Build dependency graph
     let mut graph_builder = DependencyGraphBuilder::new(false, false, false);
     graph_builder
-        .build_cross_workspace_graph(analyzer.workspaces(), analyzer.crate_to_workspace(), None)
+        .build_cross_workspace_graph(
+            analyzer.workspaces(),
+            analyzer.crate_to_workspace(),
+            analyzer.crate_path_to_workspace(),
+            analyzer.crate_to_paths(),
+            None,
+        )
         .unwrap();
 
     // Detect cycles


### PR DESCRIPTION
- replace analyzer's crate→workspace map with canonical multi-maps and expose crate-path lookups
- resolve workspace dependency edges using metadata paths instead of substring heuristics
- reindex ripple analysis on stable crate ids and update reports/tests for duplicate names
- refresh README guidance