### PR TITLE
ci: use crates.io trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,10 +40,17 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [cross-build]
+    permissions:
+      contents: write
+      discussions: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
-      - run: echo ${{ secrets.CRATES_IO_TOKEN }} | cargo login
+      - id: auth
+        uses: rust-lang/crates-io-auth-action@v1
       - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,6 @@ on:
       - v*
 env:
   CARGO_TERM_COLOR: always
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Update the crates.io publish step to use trusted publishing instead of a long-lived `CRATES_IO_TOKEN` secret.

## User Impact

Release operators no longer need to manage or rotate a crates.io API token in GitHub Actions for publishing this crate. Tagged releases can publish with a short-lived token issued through GitHub OIDC once the trusted publisher is configured on crates.io.

## Root Cause

The publish workflow authenticated with `cargo login` using `secrets.CRATES_IO_TOKEN`, which depends on a persistent registry token stored in repository secrets.

## Fix

The publish job now grants `id-token: write`, uses `rust-lang/crates-io-auth-action@v1` to request a crates.io publish token, and passes that token to `cargo publish` through `CARGO_REGISTRY_TOKEN`.

## Validation

- Pre-commit hook ran during commit and checked `.github/workflows/publish.yaml` with Prettier unchanged.
- `git diff --check HEAD~1..HEAD`
- `lefthook run pre-commit`
