### PR TITLE
ci: attest release binaries

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,8 +8,7 @@ env:
   CARGO_TERM_COLOR: always
 
 permissions:
-  contents: write
-  discussions: write
+  contents: read
 
 jobs:
   test:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,6 +40,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: [cross-build]
+    permissions:
+      contents: write
+      discussions: write
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v6
       - run: echo ${{ secrets.CRATES_IO_TOKEN }} | cargo login
@@ -100,6 +105,11 @@ jobs:
           # List all created files
           echo "Release assets:"
           ls -la *.tar.gz cargo-ferris-wheel-checksums-sha256.txt
+
+      - name: Generate artifact attestations
+        uses: actions/attest@v4
+        with:
+          subject-path: artifacts/*.tar.gz
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
## Summary

Enable GitHub artifact attestations for the release binary archives published by the `publish` workflow.

## User Impact

Users and operators can verify provenance for release tarballs downloaded from GitHub Releases, improving supply-chain visibility for published binaries.

## Root Cause

The release workflow packaged cross-built binaries into tarballs and uploaded them as release assets, but it did not generate GitHub artifact attestations for those archives.

## Fix

Add the required `id-token: write` and `attestations: write` permissions to the `publish` job, then run `actions/attest@v4` against `artifacts/*.tar.gz` after release assets are prepared and before the GitHub release is created.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "ok"' .github/workflows/publish.yaml`
- `mise x actionlint@1.7.9 -- actionlint -shellcheck= .github/workflows/publish.yaml`
