### PR TITLE
fix: preserve lineup paths for duplicate workspace names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,16 +77,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -114,15 +108,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cargo-ferris-wheel"
@@ -199,9 +193,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -211,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -221,18 +215,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "diff"
@@ -248,9 +242,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -327,15 +321,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -361,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -372,28 +364,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -423,21 +407,14 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -452,16 +429,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
-name = "log"
-version = "0.4.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miette"
@@ -599,16 +570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -654,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -677,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-demangle"
@@ -702,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -714,12 +675,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -808,9 +763,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -934,12 +889,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,28 +911,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -994,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1004,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1017,45 +948,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -1094,103 +991,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,10 +77,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.5.1"
+name = "anyhow"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -108,15 +114,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.3"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "cargo-ferris-wheel"
@@ -193,9 +199,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.4"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -205,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.7"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -215,18 +221,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.20"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.22"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "diff"
@@ -242,9 +248,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -321,13 +327,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -353,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -364,20 +372,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.6"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
@@ -407,14 +423,21 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -429,10 +452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
-name = "memchr"
-version = "2.8.3"
+name = "log"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "miette"
@@ -570,6 +599,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -615,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -638,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.11"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustc-demangle"
@@ -663,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "same-file"
@@ -675,6 +714,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -763,9 +808,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -889,6 +934,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,10 +962,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.126"
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -925,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -935,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -948,11 +1017,45 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -991,9 +1094,103 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,16 +77,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -114,15 +108,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "cargo-ferris-wheel"
@@ -199,9 +193,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -211,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -221,18 +215,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "diff"
@@ -248,9 +242,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -327,15 +321,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -361,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -372,28 +364,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.4"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -423,21 +407,14 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -452,16 +429,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
-name = "log"
-version = "0.4.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miette"
@@ -599,16 +570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -654,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -677,15 +638,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustix"
@@ -702,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -714,12 +675,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -808,9 +763,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -934,12 +889,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,28 +911,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -994,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1004,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1017,45 +948,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -1094,103 +991,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "yansi"

--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -81,6 +81,9 @@ pub struct WorkspaceDependencyAnalysis {
     direct_deps_cache: HashMap<String, HashSet<String>>,
     reverse_deps_cache: HashMap<String, HashSet<String>>,
     transitive_deps_cache: HashMap<String, HashSet<String>>,
+    direct_deps_by_path_cache: HashMap<PathBuf, HashSet<String>>,
+    reverse_deps_by_path_cache: HashMap<PathBuf, HashSet<String>>,
+    transitive_deps_by_path_cache: HashMap<PathBuf, HashSet<String>>,
 }
 
 #[derive(Debug, Clone)]
@@ -117,6 +120,9 @@ impl WorkspaceDependencyAnalysis {
             direct_deps_cache: HashMap::new(),
             reverse_deps_cache: HashMap::new(),
             transitive_deps_cache: HashMap::new(),
+            direct_deps_by_path_cache: HashMap::new(),
+            reverse_deps_by_path_cache: HashMap::new(),
+            transitive_deps_by_path_cache: HashMap::new(),
         }
     }
 
@@ -146,7 +152,11 @@ impl WorkspaceDependencyAnalysis {
             .map(|(path, _)| path)
     }
 
-    /// Get direct dependencies of a workspace
+    /// Get direct dependencies by workspace name.
+    ///
+    /// Workspace names are not guaranteed to be unique. Prefer
+    /// [`Self::get_direct_dependencies_for_path`] when the caller has a
+    /// workspace path.
     pub fn get_direct_dependencies(&mut self, workspace: &str) -> &HashSet<String> {
         if !self.direct_deps_cache.contains_key(workspace) {
             let deps = self.direct_dependencies_for(None, workspace);
@@ -157,7 +167,11 @@ impl WorkspaceDependencyAnalysis {
         &self.direct_deps_cache[workspace]
     }
 
-    /// Get workspaces that depend on this workspace (reverse dependencies)
+    /// Get workspaces that depend on this workspace by workspace name.
+    ///
+    /// Workspace names are not guaranteed to be unique. Prefer
+    /// [`Self::get_reverse_dependencies_for_path`] when the caller has a
+    /// workspace path.
     pub fn get_reverse_dependencies(&mut self, workspace: &str) -> &HashSet<String> {
         if !self.reverse_deps_cache.contains_key(workspace) {
             let deps = self.reverse_dependencies_for(None, workspace);
@@ -168,7 +182,11 @@ impl WorkspaceDependencyAnalysis {
         &self.reverse_deps_cache[workspace]
     }
 
-    /// Get all transitive dependencies of a workspace using DFS
+    /// Get all transitive dependencies by workspace name using DFS.
+    ///
+    /// Workspace names are not guaranteed to be unique. Prefer
+    /// [`Self::get_transitive_dependencies_for_path`] when the caller has a
+    /// workspace path.
     pub fn get_transitive_dependencies(&mut self, workspace: &str) -> &HashSet<String> {
         if !self.transitive_deps_cache.contains_key(workspace) {
             let deps = self.transitive_dependencies_for(None, workspace);
@@ -178,6 +196,63 @@ impl WorkspaceDependencyAnalysis {
         }
 
         &self.transitive_deps_cache[workspace]
+    }
+
+    /// Get direct dependencies by workspace path.
+    pub fn get_direct_dependencies_for_path(
+        &mut self,
+        workspace_path: impl AsRef<Path>,
+    ) -> &HashSet<String> {
+        let workspace_path = workspace_path.as_ref().to_path_buf();
+        if !self.direct_deps_by_path_cache.contains_key(&workspace_path) {
+            let deps = self.direct_dependencies_for_path(&workspace_path);
+            self.direct_deps_by_path_cache
+                .insert(workspace_path.clone(), deps);
+        }
+
+        self.direct_deps_by_path_cache
+            .get(&workspace_path)
+            .expect("path cache should contain computed direct dependencies")
+    }
+
+    /// Get workspaces that depend on this workspace by workspace path.
+    pub fn get_reverse_dependencies_for_path(
+        &mut self,
+        workspace_path: impl AsRef<Path>,
+    ) -> &HashSet<String> {
+        let workspace_path = workspace_path.as_ref().to_path_buf();
+        if !self
+            .reverse_deps_by_path_cache
+            .contains_key(&workspace_path)
+        {
+            let deps = self.reverse_dependencies_for_path(&workspace_path);
+            self.reverse_deps_by_path_cache
+                .insert(workspace_path.clone(), deps);
+        }
+
+        self.reverse_deps_by_path_cache
+            .get(&workspace_path)
+            .expect("path cache should contain computed reverse dependencies")
+    }
+
+    /// Get all transitive dependencies by workspace path using DFS.
+    pub fn get_transitive_dependencies_for_path(
+        &mut self,
+        workspace_path: impl AsRef<Path>,
+    ) -> &HashSet<String> {
+        let workspace_path = workspace_path.as_ref().to_path_buf();
+        if !self
+            .transitive_deps_by_path_cache
+            .contains_key(&workspace_path)
+        {
+            let deps = self.transitive_dependencies_for_path(&workspace_path);
+            self.transitive_deps_by_path_cache
+                .insert(workspace_path.clone(), deps);
+        }
+
+        self.transitive_deps_by_path_cache
+            .get(&workspace_path)
+            .expect("path cache should contain computed transitive dependencies")
     }
 
     fn node_index_for(
@@ -207,6 +282,19 @@ impl WorkspaceDependencyAnalysis {
         deps
     }
 
+    fn direct_dependencies_for_path(&self, workspace_path: &Path) -> HashSet<String> {
+        let mut deps = HashSet::new();
+
+        if let Some(&node_idx) = self.node_indices_by_path.get(workspace_path) {
+            for edge in self.graph.edges(node_idx) {
+                let target_node = &self.graph[edge.target()];
+                deps.insert(target_node.name().to_string());
+            }
+        }
+
+        deps
+    }
+
     fn reverse_dependencies_for(
         &self,
         workspace_path: Option<&Path>,
@@ -215,6 +303,19 @@ impl WorkspaceDependencyAnalysis {
         let mut deps = HashSet::new();
 
         if let Some(node_idx) = self.node_index_for(workspace_path, workspace_name) {
+            for edge in self.graph.edges_directed(node_idx, petgraph::Incoming) {
+                let source_node = &self.graph[edge.source()];
+                deps.insert(source_node.name().to_string());
+            }
+        }
+
+        deps
+    }
+
+    fn reverse_dependencies_for_path(&self, workspace_path: &Path) -> HashSet<String> {
+        let mut deps = HashSet::new();
+
+        if let Some(&node_idx) = self.node_indices_by_path.get(workspace_path) {
             for edge in self.graph.edges_directed(node_idx, petgraph::Incoming) {
                 let source_node = &self.graph[edge.source()];
                 deps.insert(source_node.name().to_string());
@@ -233,6 +334,17 @@ impl WorkspaceDependencyAnalysis {
         let mut deps = HashSet::new();
 
         if let Some(node_idx) = self.node_index_for(workspace_path, workspace_name) {
+            self.dfs_dependencies(node_idx, &mut visited, &mut deps);
+        }
+
+        deps
+    }
+
+    fn transitive_dependencies_for_path(&self, workspace_path: &Path) -> HashSet<String> {
+        let mut visited = HashSet::new();
+        let mut deps = HashSet::new();
+
+        if let Some(&node_idx) = self.node_indices_by_path.get(workspace_path) {
             self.dfs_dependencies(node_idx, &mut visited, &mut deps);
         }
 
@@ -487,17 +599,25 @@ impl WorkspaceDepsReportGenerator {
 
     fn dependencies_for_entry(
         &self,
-        analysis: &WorkspaceDependencyAnalysis,
+        analysis: &mut WorkspaceDependencyAnalysis,
         workspace: &WorkspaceReportEntry,
     ) -> HashSet<String> {
-        let path = workspace.path.as_deref();
-
-        if self.reverse {
-            analysis.reverse_dependencies_for(path, &workspace.name)
+        if let Some(path) = &workspace.path {
+            if self.reverse {
+                analysis.get_reverse_dependencies_for_path(path).clone()
+            } else if self.transitive {
+                analysis.get_transitive_dependencies_for_path(path).clone()
+            } else {
+                analysis.get_direct_dependencies_for_path(path).clone()
+            }
+        } else if self.reverse {
+            analysis.get_reverse_dependencies(&workspace.name).clone()
         } else if self.transitive {
-            analysis.transitive_dependencies_for(path, &workspace.name)
+            analysis
+                .get_transitive_dependencies(&workspace.name)
+                .clone()
         } else {
-            analysis.direct_dependencies_for(path, &workspace.name)
+            analysis.get_direct_dependencies(&workspace.name).clone()
         }
     }
 }
@@ -522,10 +642,15 @@ mod tests {
         let mut workspaces = HashMap::new();
         let crate_to_workspace = CrateWorkspaceMap::new();
 
+        let path_a = PathBuf::from("/test/workspace-a");
+        let path_b = PathBuf::from("/test/workspace-b");
+        let path_c = PathBuf::from("/test/workspace-c");
+
         // Create workspace nodes
         let node_a = graph.add_node(
             WorkspaceNode::builder()
                 .with_name("workspace-a".to_string())
+                .with_path(path_a.clone())
                 .with_crates(vec!["crate-a".to_string()])
                 .build()
                 .unwrap(),
@@ -534,6 +659,7 @@ mod tests {
         let node_b = graph.add_node(
             WorkspaceNode::builder()
                 .with_name("workspace-b".to_string())
+                .with_path(path_b.clone())
                 .with_crates(vec!["crate-b".to_string()])
                 .build()
                 .unwrap(),
@@ -542,6 +668,7 @@ mod tests {
         let node_c = graph.add_node(
             WorkspaceNode::builder()
                 .with_name("workspace-c".to_string())
+                .with_path(path_c.clone())
                 .with_crates(vec!["crate-c".to_string()])
                 .build()
                 .unwrap(),
@@ -569,11 +696,6 @@ mod tests {
                 .build()
                 .unwrap(),
         );
-
-        // Create mock workspace info
-        let path_a = PathBuf::from("/test/workspace-a");
-        let path_b = PathBuf::from("/test/workspace-b");
-        let path_c = PathBuf::from("/test/workspace-c");
 
         workspaces.insert(
             path_a.clone(),
@@ -701,8 +823,9 @@ mod tests {
         let mut graph = DiGraph::new();
         let main_tools_path = PathBuf::from("/test/main/tools");
         let standalone_tools_path = PathBuf::from("/test/standalone-runner");
+        let core_path = PathBuf::from("/test/core");
 
-        graph.add_node(
+        let main_tools = graph.add_node(
             WorkspaceNode::builder()
                 .with_name("tools".to_string())
                 .with_path(main_tools_path.clone())
@@ -715,6 +838,24 @@ mod tests {
                 .with_name("tools".to_string())
                 .with_path(standalone_tools_path.clone())
                 .with_crates(vec!["tools".to_string()])
+                .build()
+                .unwrap(),
+        );
+        let core = graph.add_node(
+            WorkspaceNode::builder()
+                .with_name("core".to_string())
+                .with_path(core_path.clone())
+                .with_crates(vec!["core".to_string()])
+                .build()
+                .unwrap(),
+        );
+        graph.add_edge(
+            main_tools,
+            core,
+            DependencyEdge::builder()
+                .with_from_crate("tools-cli")
+                .with_to_crate("core")
+                .with_dependency_type(crate::graph::DependencyType::Normal)
                 .build()
                 .unwrap(),
         );
@@ -737,9 +878,27 @@ mod tests {
                 .build()
                 .unwrap(),
         );
+        workspaces.insert(
+            core_path,
+            WorkspaceInfo::builder()
+                .with_name("core")
+                .with_members(vec![])
+                .build()
+                .unwrap(),
+        );
 
         let mut analysis =
             WorkspaceDependencyAnalysis::new(&workspaces, &CrateWorkspaceMap::new(), &graph);
+        let main_deps = analysis
+            .get_direct_dependencies_for_path(&main_tools_path)
+            .clone();
+        let standalone_deps = analysis
+            .get_direct_dependencies_for_path(&standalone_tools_path)
+            .clone();
+
+        assert_eq!(main_deps, HashSet::from(["core".to_string()]));
+        assert!(standalone_deps.is_empty());
+
         let report = WorkspaceDepsReportGenerator::new(None, false, false)
             .generate_json_report(&mut analysis)
             .unwrap();
@@ -751,7 +910,7 @@ mod tests {
             .map(|workspace| workspace.path.as_str())
             .collect();
 
-        assert_eq!(json.workspaces.len(), 2);
+        assert_eq!(json.workspaces.len(), 3);
         assert!(paths.contains("/test/main/tools"));
         assert!(paths.contains("/test/standalone-runner"));
     }

--- a/src/commands/deps.rs
+++ b/src/commands/deps.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fmt::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use miette::{Result, WrapErr};
 use petgraph::graph::{DiGraph, NodeIndex};
@@ -76,10 +76,18 @@ pub struct WorkspaceDependencyAnalysis {
     workspaces: HashMap<PathBuf, WorkspaceInfo>,
     graph: DiGraph<WorkspaceNode, DependencyEdge>,
     node_indices: HashMap<String, NodeIndex>,
+    node_indices_by_path: HashMap<PathBuf, NodeIndex>,
     // Cache for computed dependencies
     direct_deps_cache: HashMap<String, HashSet<String>>,
     reverse_deps_cache: HashMap<String, HashSet<String>>,
     transitive_deps_cache: HashMap<String, HashSet<String>>,
+}
+
+#[derive(Debug, Clone)]
+struct WorkspaceReportEntry {
+    name: String,
+    path: Option<PathBuf>,
+    is_standalone: bool,
 }
 
 impl WorkspaceDependencyAnalysis {
@@ -90,8 +98,12 @@ impl WorkspaceDependencyAnalysis {
     ) -> Self {
         // Build node index lookup
         let mut node_indices = HashMap::new();
+        let mut node_indices_by_path = HashMap::new();
         for (idx, node) in graph.node_references() {
             node_indices.insert(node.name(), idx);
+            if let Some(path) = node.path() {
+                node_indices_by_path.insert(path.to_path_buf(), idx);
+            }
         }
 
         Self {
@@ -101,6 +113,7 @@ impl WorkspaceDependencyAnalysis {
                 .into_iter()
                 .map(|(k, v)| (k.to_string(), v))
                 .collect(),
+            node_indices_by_path,
             direct_deps_cache: HashMap::new(),
             reverse_deps_cache: HashMap::new(),
             transitive_deps_cache: HashMap::new(),
@@ -136,14 +149,7 @@ impl WorkspaceDependencyAnalysis {
     /// Get direct dependencies of a workspace
     pub fn get_direct_dependencies(&mut self, workspace: &str) -> &HashSet<String> {
         if !self.direct_deps_cache.contains_key(workspace) {
-            let mut deps = HashSet::new();
-
-            if let Some(&node_idx) = self.node_indices.get(workspace) {
-                for edge in self.graph.edges(node_idx) {
-                    let target_node = &self.graph[edge.target()];
-                    deps.insert(target_node.name().to_string());
-                }
-            }
+            let deps = self.direct_dependencies_for(None, workspace);
 
             self.direct_deps_cache.insert(workspace.to_string(), deps);
         }
@@ -154,14 +160,7 @@ impl WorkspaceDependencyAnalysis {
     /// Get workspaces that depend on this workspace (reverse dependencies)
     pub fn get_reverse_dependencies(&mut self, workspace: &str) -> &HashSet<String> {
         if !self.reverse_deps_cache.contains_key(workspace) {
-            let mut deps = HashSet::new();
-
-            if let Some(&node_idx) = self.node_indices.get(workspace) {
-                for edge in self.graph.edges_directed(node_idx, petgraph::Incoming) {
-                    let source_node = &self.graph[edge.source()];
-                    deps.insert(source_node.name().to_string());
-                }
-            }
+            let deps = self.reverse_dependencies_for(None, workspace);
 
             self.reverse_deps_cache.insert(workspace.to_string(), deps);
         }
@@ -172,18 +171,72 @@ impl WorkspaceDependencyAnalysis {
     /// Get all transitive dependencies of a workspace using DFS
     pub fn get_transitive_dependencies(&mut self, workspace: &str) -> &HashSet<String> {
         if !self.transitive_deps_cache.contains_key(workspace) {
-            let mut visited = HashSet::new();
-            let mut deps = HashSet::new();
-
-            if let Some(&node_idx) = self.node_indices.get(workspace) {
-                self.dfs_dependencies(node_idx, &mut visited, &mut deps);
-            }
+            let deps = self.transitive_dependencies_for(None, workspace);
 
             self.transitive_deps_cache
                 .insert(workspace.to_string(), deps);
         }
 
         &self.transitive_deps_cache[workspace]
+    }
+
+    fn node_index_for(
+        &self,
+        workspace_path: Option<&Path>,
+        workspace_name: &str,
+    ) -> Option<NodeIndex> {
+        workspace_path
+            .and_then(|path| self.node_indices_by_path.get(path).copied())
+            .or_else(|| self.node_indices.get(workspace_name).copied())
+    }
+
+    fn direct_dependencies_for(
+        &self,
+        workspace_path: Option<&Path>,
+        workspace_name: &str,
+    ) -> HashSet<String> {
+        let mut deps = HashSet::new();
+
+        if let Some(node_idx) = self.node_index_for(workspace_path, workspace_name) {
+            for edge in self.graph.edges(node_idx) {
+                let target_node = &self.graph[edge.target()];
+                deps.insert(target_node.name().to_string());
+            }
+        }
+
+        deps
+    }
+
+    fn reverse_dependencies_for(
+        &self,
+        workspace_path: Option<&Path>,
+        workspace_name: &str,
+    ) -> HashSet<String> {
+        let mut deps = HashSet::new();
+
+        if let Some(node_idx) = self.node_index_for(workspace_path, workspace_name) {
+            for edge in self.graph.edges_directed(node_idx, petgraph::Incoming) {
+                let source_node = &self.graph[edge.source()];
+                deps.insert(source_node.name().to_string());
+            }
+        }
+
+        deps
+    }
+
+    fn transitive_dependencies_for(
+        &self,
+        workspace_path: Option<&Path>,
+        workspace_name: &str,
+    ) -> HashSet<String> {
+        let mut visited = HashSet::new();
+        let mut deps = HashSet::new();
+
+        if let Some(node_idx) = self.node_index_for(workspace_path, workspace_name) {
+            self.dfs_dependencies(node_idx, &mut visited, &mut deps);
+        }
+
+        deps
     }
 
     /// Depth-first search to find all transitive dependencies
@@ -229,27 +282,24 @@ impl WorkspaceDepsReportGenerator {
     ) -> Result<String, FerrisWheelError> {
         let mut output = String::new();
 
-        let workspaces = if let Some(ref filter) = self.workspace_filter {
-            vec![filter.clone()]
-        } else {
-            analysis.workspace_names()
-        };
+        let workspaces = self.selected_workspace_entries(analysis);
 
         for workspace in workspaces {
-            writeln!(output, "\n📦 Workspace: {workspace}")?;
+            writeln!(output, "\n📦 Workspace: {}", workspace.name)?;
 
             // Add workspace path if available
-            if let Some(workspace_path) = analysis.get_workspace_path(&workspace) {
+            if let Some(workspace_path) = &workspace.path {
                 writeln!(output, "  📍 Path: {}", workspace_path.display())?;
             }
 
+            let deps = self.dependencies_for_entry(analysis, &workspace);
+
             if self.reverse {
                 writeln!(output, "  ⬆️  Reverse dependencies (who depends on this):")?;
-                let reverse_deps = analysis.get_reverse_dependencies(&workspace);
-                if reverse_deps.is_empty() {
+                if deps.is_empty() {
                     writeln!(output, "    (none)")?;
                 } else {
-                    let mut sorted_deps: Vec<_> = reverse_deps.iter().cloned().collect();
+                    let mut sorted_deps: Vec<_> = deps.into_iter().collect();
                     sorted_deps.sort();
                     for dep in sorted_deps {
                         writeln!(output, "    - {dep}")?;
@@ -257,11 +307,10 @@ impl WorkspaceDepsReportGenerator {
                 }
             } else if self.transitive {
                 writeln!(output, "  ⬇️  All transitive dependencies:")?;
-                let transitive_deps = analysis.get_transitive_dependencies(&workspace);
-                if transitive_deps.is_empty() {
+                if deps.is_empty() {
                     writeln!(output, "    (none)")?;
                 } else {
-                    let mut sorted_deps: Vec<_> = transitive_deps.iter().cloned().collect();
+                    let mut sorted_deps: Vec<_> = deps.into_iter().collect();
                     sorted_deps.sort();
                     for dep in sorted_deps {
                         writeln!(output, "    - {dep}")?;
@@ -269,11 +318,10 @@ impl WorkspaceDepsReportGenerator {
                 }
             } else {
                 writeln!(output, "  ⬇️  Direct dependencies:")?;
-                let direct_deps = analysis.get_direct_dependencies(&workspace);
-                if direct_deps.is_empty() {
+                if deps.is_empty() {
                     writeln!(output, "    (none)")?;
                 } else {
-                    let mut sorted_deps: Vec<_> = direct_deps.iter().cloned().collect();
+                    let mut sorted_deps: Vec<_> = deps.into_iter().collect();
                     sorted_deps.sort();
                     for dep in sorted_deps {
                         writeln!(output, "    - {dep}")?;
@@ -289,60 +337,33 @@ impl WorkspaceDepsReportGenerator {
         &self,
         analysis: &mut WorkspaceDependencyAnalysis,
     ) -> Result<String, FerrisWheelError> {
-        let workspaces = if let Some(ref filter) = self.workspace_filter {
-            vec![filter.clone()]
-        } else {
-            analysis.workspace_names()
-        };
+        let workspaces = self.selected_workspace_entries(analysis);
 
         let mut workspace_data = Vec::new();
 
         for workspace in workspaces {
-            let deps = if self.reverse {
-                analysis
-                    .get_reverse_dependencies(&workspace)
-                    .iter()
-                    .cloned()
-                    .collect::<Vec<_>>()
-            } else if self.transitive {
-                analysis
-                    .get_transitive_dependencies(&workspace)
-                    .iter()
-                    .cloned()
-                    .collect::<Vec<_>>()
-            } else {
-                analysis
-                    .get_direct_dependencies(&workspace)
-                    .iter()
-                    .cloned()
-                    .collect::<Vec<_>>()
-            };
+            let deps = self.dependencies_for_entry(analysis, &workspace);
 
-            let is_standalone = analysis
-                .get_workspace_info(&workspace)
-                .map(|info| info.is_standalone())
-                .unwrap_or(false);
-
-            let workspace_path = analysis
-                .get_workspace_path(&workspace)
+            let workspace_path = workspace
+                .path
+                .as_ref()
                 .map(|p| p.display().to_string())
                 .unwrap_or_else(|| "(unknown)".to_string());
 
-            let mut sorted_deps = deps;
+            let mut sorted_deps = deps.into_iter().collect::<Vec<_>>();
             sorted_deps.sort();
 
             workspace_data.push(WorkspaceDepsEntry {
-                name: workspace.clone(),
+                name: workspace.name,
                 path: workspace_path,
                 dependencies: sorted_deps,
                 reverse: self.reverse,
                 transitive: self.transitive,
-                is_standalone,
+                is_standalone: workspace.is_standalone,
             });
         }
 
-        // Sort workspace_data by workspace name for consistent output
-        workspace_data.sort_by(|a, b| a.name.cmp(&b.name));
+        workspace_data.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.path.cmp(&b.path)));
 
         let report = WorkspaceDepsJsonReport {
             workspaces: workspace_data,
@@ -371,23 +392,13 @@ impl WorkspaceDepsReportGenerator {
             r#"    <testcase name="analyze-workspace-dependencies" classname="ferris-wheel">"#
         )?;
 
-        let workspaces = if let Some(ref filter) = self.workspace_filter {
-            vec![filter.clone()]
-        } else {
-            analysis.workspace_names()
-        };
+        let workspaces = self.selected_workspace_entries(analysis);
 
         writeln!(output, "Workspace dependency analysis results:")?;
         for workspace in workspaces {
-            let deps = if self.reverse {
-                analysis.get_reverse_dependencies(&workspace)
-            } else if self.transitive {
-                analysis.get_transitive_dependencies(&workspace)
-            } else {
-                analysis.get_direct_dependencies(&workspace)
-            };
+            let deps = self.dependencies_for_entry(analysis, &workspace);
 
-            writeln!(output, "  {}: {} dependencies", workspace, deps.len())?;
+            writeln!(output, "  {}: {} dependencies", workspace.name, deps.len())?;
         }
 
         writeln!(output, r#"    </testcase>"#)?;
@@ -403,11 +414,7 @@ impl WorkspaceDepsReportGenerator {
     ) -> Result<String, FerrisWheelError> {
         let mut output = String::new();
 
-        let workspaces = if let Some(ref filter) = self.workspace_filter {
-            vec![filter.clone()]
-        } else {
-            analysis.workspace_names()
-        };
+        let workspaces = self.selected_workspace_entries(analysis);
 
         writeln!(
             output,
@@ -417,13 +424,7 @@ impl WorkspaceDepsReportGenerator {
         )?;
 
         for workspace in workspaces {
-            let deps = if self.reverse {
-                analysis.get_reverse_dependencies(&workspace)
-            } else if self.transitive {
-                analysis.get_transitive_dependencies(&workspace)
-            } else {
-                analysis.get_direct_dependencies(&workspace)
-            };
+            let deps = self.dependencies_for_entry(analysis, &workspace);
 
             let dep_type = if self.reverse {
                 "reverse"
@@ -433,14 +434,15 @@ impl WorkspaceDepsReportGenerator {
                 "direct"
             };
 
-            let mut sorted_deps: Vec<_> = deps.iter().cloned().collect();
+            let dep_count = deps.len();
+            let mut sorted_deps: Vec<_> = deps.into_iter().collect();
             sorted_deps.sort();
 
             writeln!(
                 output,
                 "::notice title={}::{} {} dependencies: {}",
-                workspace,
-                deps.len(),
+                workspace.name,
+                dep_count,
                 dep_type,
                 sorted_deps.join(", ")
             )?;
@@ -448,11 +450,61 @@ impl WorkspaceDepsReportGenerator {
 
         Ok(output)
     }
+
+    fn selected_workspace_entries(
+        &self,
+        analysis: &WorkspaceDependencyAnalysis,
+    ) -> Vec<WorkspaceReportEntry> {
+        let mut entries: Vec<_> = analysis
+            .workspaces
+            .iter()
+            .filter(|(_, workspace)| {
+                self.workspace_filter
+                    .as_ref()
+                    .is_none_or(|filter| workspace.name() == filter)
+            })
+            .map(|(path, workspace)| WorkspaceReportEntry {
+                name: workspace.name().to_string(),
+                path: Some(path.clone()),
+                is_standalone: workspace.is_standalone(),
+            })
+            .collect();
+
+        entries.sort_by(|a, b| a.name.cmp(&b.name).then_with(|| a.path.cmp(&b.path)));
+
+        if entries.is_empty()
+            && let Some(filter) = &self.workspace_filter
+        {
+            entries.push(WorkspaceReportEntry {
+                name: filter.clone(),
+                path: None,
+                is_standalone: false,
+            });
+        }
+
+        entries
+    }
+
+    fn dependencies_for_entry(
+        &self,
+        analysis: &WorkspaceDependencyAnalysis,
+        workspace: &WorkspaceReportEntry,
+    ) -> HashSet<String> {
+        let path = workspace.path.as_deref();
+
+        if self.reverse {
+            analysis.reverse_dependencies_for(path, &workspace.name)
+        } else if self.transitive {
+            analysis.transitive_dependencies_for(path, &workspace.name)
+        } else {
+            analysis.direct_dependencies_for(path, &workspace.name)
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::path::PathBuf;
 
     use petgraph::graph::DiGraph;
@@ -642,5 +694,65 @@ mod tests {
         let workspace_deps = json["workspaces"].as_array().unwrap();
         assert!(!workspace_deps.is_empty());
         assert!(workspace_deps[0]["path"].is_string());
+    }
+
+    #[test]
+    fn test_json_report_preserves_paths_for_duplicate_workspace_names() {
+        let mut graph = DiGraph::new();
+        let main_tools_path = PathBuf::from("/test/main/tools");
+        let standalone_tools_path = PathBuf::from("/test/standalone-runner");
+
+        graph.add_node(
+            WorkspaceNode::builder()
+                .with_name("tools".to_string())
+                .with_path(main_tools_path.clone())
+                .with_crates(vec!["tools-cli".to_string()])
+                .build()
+                .unwrap(),
+        );
+        graph.add_node(
+            WorkspaceNode::builder()
+                .with_name("tools".to_string())
+                .with_path(standalone_tools_path.clone())
+                .with_crates(vec!["tools".to_string()])
+                .build()
+                .unwrap(),
+        );
+
+        let mut workspaces = HashMap::new();
+        workspaces.insert(
+            main_tools_path.clone(),
+            WorkspaceInfo::builder()
+                .with_name("tools")
+                .with_members(vec![])
+                .build()
+                .unwrap(),
+        );
+        workspaces.insert(
+            standalone_tools_path.clone(),
+            WorkspaceInfo::builder()
+                .with_name("tools")
+                .with_members(vec![])
+                .with_is_standalone(true)
+                .build()
+                .unwrap(),
+        );
+
+        let mut analysis =
+            WorkspaceDependencyAnalysis::new(&workspaces, &CrateWorkspaceMap::new(), &graph);
+        let report = WorkspaceDepsReportGenerator::new(None, false, false)
+            .generate_json_report(&mut analysis)
+            .unwrap();
+        let json: WorkspaceDepsJsonReport = serde_json::from_str(&report).unwrap();
+
+        let paths: HashSet<_> = json
+            .workspaces
+            .iter()
+            .map(|workspace| workspace.path.as_str())
+            .collect();
+
+        assert_eq!(json.workspaces.len(), 2);
+        assert!(paths.contains("/test/main/tools"));
+        assert!(paths.contains("/test/standalone-runner"));
     }
 }

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -257,6 +257,7 @@ impl DependencyGraphBuilder {
         for (ws_path, ws_info) in workspaces {
             let node = WorkspaceNode::builder()
                 .with_name(ws_info.name().to_string())
+                .with_path(ws_path.clone())
                 .with_crates(
                     ws_info
                         .members()

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -3,10 +3,13 @@
 //! This module contains the fundamental data structures used in the dependency
 //! graph.
 
+use std::path::{Path, PathBuf};
+
 /// Represents a workspace node in the dependency graph
 #[derive(Debug, Clone)]
 pub struct WorkspaceNode {
     name: String,
+    path: Option<PathBuf>,
     crates: Vec<String>,
 }
 
@@ -19,6 +22,10 @@ impl WorkspaceNode {
         &self.name
     }
 
+    pub fn path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
+
     pub fn crates(&self) -> &[String] {
         &self.crates
     }
@@ -27,6 +34,7 @@ impl WorkspaceNode {
 #[derive(Default)]
 pub struct WorkspaceNodeBuilder {
     name: Option<String>,
+    path: Option<PathBuf>,
     crates: Option<Vec<String>>,
 }
 
@@ -34,12 +42,18 @@ impl WorkspaceNodeBuilder {
     pub fn new() -> Self {
         Self {
             name: None,
+            path: None,
             crates: None,
         }
     }
 
     pub fn with_name(mut self, name: String) -> Self {
         self.name = Some(name);
+        self
+    }
+
+    pub fn with_path(mut self, path: PathBuf) -> Self {
+        self.path = Some(path);
         self
     }
 
@@ -59,6 +73,7 @@ impl crate::common::ConfigBuilder for WorkspaceNodeBuilder {
                 .ok_or_else(|| crate::error::FerrisWheelError::ConfigurationError {
                     message: "Missing required field: name".to_string(),
                 })?,
+            path: self.path,
             crates: self.crates.ok_or_else(|| {
                 crate::error::FerrisWheelError::ConfigurationError {
                     message: "Missing required field: crates".to_string(),


### PR DESCRIPTION
## Summary

Fix `cargo ferris-wheel lineup` reports so duplicate workspace names keep their own paths instead of being resolved through a name-only lookup.

## User Impact

Automation that consumes `lineup --format json`, such as workspace cleanup or per-workspace cargo tasks, can skip or duplicate a workspace when two discovered entries share the same name. This makes downstream tooling unreliable even though discovery found the underlying paths.

## Root Cause

The lineup report path used workspace names as report identities. Workspace names are not guaranteed to be unique, and the report later looked paths back up by scanning a `HashMap` for the first matching name. With duplicate names, that can return the wrong path depending on map iteration order.

## Fix

Workspace graph nodes now carry the workspace path that produced them. Lineup report generation builds path-backed report entries containing the name, path, and standalone flag, and dependency lookups can resolve nodes by path before falling back to name. A regression test covers two entries named `tools` and verifies both distinct JSON paths are preserved.

## Validation

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `cargo nextest run --profile ci --cargo-profile ci` fails because Cargo profile `ci` is not defined in this repository
- Manual Phoenix smoke: local `lineup --format json` still reports `/Users/brenden/dev/phoenix/tools`
